### PR TITLE
Suggestion for trying to get docker pushes working

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -206,6 +206,11 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         proxy_ignore_client_abort on;
         proxy_cache_revalidate on;
 
+        # Make docker pushes work
+        proxy_cache_convert_head off;
+        proxy_cache_methods GET;
+        proxy_cache_key $scheme$request_method$proxy_host$request_uri;
+        
         # Hide/ignore headers from caching. S3 especially likes to send Expires headers in the past in some situations.
         proxy_hide_header      Set-Cookie;
         proxy_ignore_headers   X-Accel-Expires Expires Cache-Control Set-Cookie;


### PR DESCRIPTION
I borrowed some parts of your config for a reverse proxy I run. I was able to get pushes to work with caching with the above settings. I thought they /might/ work for you.

FWIW the proxy I run sits in front of our private docker registry and translates everything with the follwoing location block:
```
        location / {
            proxy_cache off;
            set $backend https://$private_docker_server;
            proxy_pass     $backend;
            proxy_redirect $backend https://proxy-hostname;
        }
```